### PR TITLE
Feat: A couple of patches

### DIFF
--- a/k8s/auth.tf
+++ b/k8s/auth.tf
@@ -114,7 +114,7 @@ resource "kubernetes_manifest" "vso_db_demo" {
       mount = "demo-db"
       path  = "creds/${vault_database_secret_backend_role.dev_postgres.name}"
       destination = {
-        create = false
+        create = true
         name   = "vso-db-demo"
       }
       rolloutRestartTargets = [
@@ -147,14 +147,6 @@ resource "kubernetes_manifest" "dynamic_auth" {
     }
   }
 }
-
-resource "kubernetes_secret" "vso_db_demo" {
-  metadata {
-    name      = "vso-db-demo"
-    namespace = kubernetes_namespace.demo_ns.metadata[0].name
-  }
-}
-
 
 # TLS Auth
 resource "kubernetes_manifest" "tls_auth" {

--- a/k8s/postgres.tf
+++ b/k8s/postgres.tf
@@ -63,7 +63,7 @@ resource "vault_kubernetes_auth_backend_role" "auth_role" {
 
 # App Deployment with mounted secret
 resource "kubernetes_deployment" "vso_db_demo" {
-  depends_on = [kubernetes_secret.vso_db_demo]
+  depends_on = [kubernetes_manifest.vso_db_demo]
   metadata {
     name      = "vso-db-demo"
     namespace = kubernetes_namespace.demo_ns.metadata[0].name

--- a/vault/vault.tf
+++ b/vault/vault.tf
@@ -31,6 +31,7 @@ resource "helm_release" "vault" {
   chart            = "vault"
   namespace        = "vault"
   create_namespace = true
+  wait_for_jobs    = true
 
   set {
     name  = "server.dev.enabled"

--- a/vault/vault.tf
+++ b/vault/vault.tf
@@ -53,11 +53,6 @@ resource "helm_release" "vault" {
   }
 
   set {
-    name  = "ui.serviceType"
-    value = "LoadBalancer"
-  }
-
-  set {
     name  = "ui.externalPort"
     value = "8200"
   }


### PR DESCRIPTION
Hi Amar,

I'm currently using your demo and had to adjust a couple of things. Feel free to cherry-pick :) . Ths PR entails:
* bump VSO to latest release
* therefore kubernetes secret resource for dynamic secret is no longer required
* replaced LoadBalancer type requirement with `kubectl port-forward`
* additionally added a `port-forward` for postgres to be able to connect directly if required
* fixed url for postgresql helm chart

Something else I noticed and is worth to mention: I have used rootless kind for this. Therefore I needed to create the cluster with `localStorageCapacityIsolation: true` because postgresql default helm chart wants a pvc. E.g.:

```
cat <<EOF | kind create cluster --name vso-demo --config=-
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
kubeadmConfigPatches:
- |
  kind: KubeletConfiguration
  localStorageCapacityIsolation: true
EOF
```